### PR TITLE
Searches for authorized_keys at user's home dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ openssl-sys = "^0.9"
 openssl = "^0.10"
 log = { version = "^0.4", features = ["std", "serde"] }
 syslog = "^5.0"
+pwd = "1"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ The following arguments are supported:
 - `loglevel=<off|error|warn|info|debug|trace>` Select the level of messages logged to syslog. Defaults to `warn`.
 - `debug` Equivalent to `loglevel=debug`. 
 - `ssh_agent_addr=<IP:port or UNIX domain address>` The address of ssh-agent. Defaults to the value of `SSH_AUTH_SOCK` environment variable, which is set by ssh automatically.
-- `auth_key_file=<Path to authorized_keys>` Public keys allowed for user authentication. Defaults to `/home/<username>/.ssh/authorized_keys`.
+- `auth_key_file=<Path to authorized_keys>` Public keys allowed for user authentication. Defaults to `$HOME/.ssh/authorized_keys`. Usually `$HOME` expands to `/home/<username>`.
 
 Arguments should be appended to the PAM rule. For example, `auth sufficient /usr/local/lib/libpam_rssh.so debug`.

--- a/src/auth_keys.rs
+++ b/src/auth_keys.rs
@@ -1,4 +1,5 @@
 use log::*;
+use pwd::Passwd;
 use ssh_agent::proto::from_bytes;
 use ssh_agent::proto::public_key::PublicKey;
 
@@ -71,7 +72,13 @@ pub fn parse_authorized_keys(filename: &str) -> Result<Vec<PublicKey>, ErrType> 
 }
 
 pub fn parse_user_authorized_keys(username: &str) -> Result<Vec<PublicKey>, ErrType> {
-    let path: PathBuf = ["/home", username, ".ssh", "authorized_keys"]
+    let mut prefix = format!("/home/{}",username);
+    // Gets user's $HOME to search for authorized_keys
+    let pwd = Passwd::from_name(username).unwrap();
+    if let Some(passwd) = pwd {
+        prefix = passwd.dir;
+    }
+    let path: PathBuf = [prefix.as_str(), ".ssh", "authorized_keys"]
         .iter()
         .collect();
     parse_authorized_keys(path.to_str().ok_or(RsshErr::GetHomeErr)?)

--- a/src/auth_keys.rs
+++ b/src/auth_keys.rs
@@ -74,10 +74,11 @@ pub fn parse_authorized_keys(filename: &str) -> Result<Vec<PublicKey>, ErrType> 
 pub fn parse_user_authorized_keys(username: &str) -> Result<Vec<PublicKey>, ErrType> {
     let mut prefix = format!("/home/{}",username);
     // Gets user's $HOME to search for authorized_keys
-    let pwd = Passwd::from_name(username).unwrap();
-    if let Some(passwd) = pwd {
-        prefix = passwd.dir;
-    }
+    let _ = Passwd::from_name(username).map(|opt_passwd| {
+        opt_passwd.map(|passwd| {
+            prefix = passwd.dir;
+        })
+    });
     let path: PathBuf = [prefix.as_str(), ".ssh", "authorized_keys"]
         .iter()
         .collect();


### PR DESCRIPTION
Changes the default place to search for `authorized_keys` file.

Instead using hardcoded `/home/<username>/.ssh/authorized_keys`, uses the user's home directory as returned by `getpwnam`. Some users (notably, `root`) have their home directories outside `/home`.

Closes #1