### PR TITLE
use https in `.gitmodules`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/z4yx/pam-rs.git
 [submodule "dep/ssh-agent.rs"]
 	path = dep/ssh-agent.rs
-	url = git@github.com:z4yx/ssh-agent.rs.git
+	url = https://github.com/z4yx/ssh-agent.rs.git


### PR DESCRIPTION
`https://github.com/z4yx/ssh-agent.rs.git` is a public repository, and using SSH instead of HTTP makes it more difficult to package this project for NixOS.