### PR TITLE
Switch back to upstream pam-bindings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "dep/pam-rs"]
-	path = dep/pam-rs
-	url = https://github.com/z4yx/pam-rs.git
 [submodule "dep/ssh-agent.rs"]
 	path = dep/ssh-agent.rs
 	url = https://github.com/z4yx/ssh-agent.rs.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,12 +70,6 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "libc"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
-
-[[package]]
-name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
@@ -111,7 +105,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
- "libc 0.2.139",
+ "libc",
  "once_cell",
  "openssl-macros",
  "openssl-sys",
@@ -136,16 +130,18 @@ checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
- "libc 0.2.139",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
 
 [[package]]
-name = "pam"
-version = "0.1.0"
+name = "pam-bindings"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c337e922acb6ab9c3ddd1016fed13957a5bf14f51b6caa293ddc8dd47660ca"
 dependencies = [
- "libc 0.1.12",
+ "libc",
 ]
 
 [[package]]
@@ -158,7 +154,7 @@ dependencies = [
  "multisock",
  "openssl",
  "openssl-sys",
- "pam",
+ "pam-bindings",
  "pwd",
  "ssh-agent",
  "syslog",
@@ -185,7 +181,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c71c0c79b9701efe4e1e4b563b2016dd4ee789eb99badcb09d61ac4b92e4a2"
 dependencies = [
- "libc 0.2.139",
+ "libc",
  "thiserror",
 ]
 
@@ -246,7 +242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5d8ef1b679c07976f3ee336a436453760c470f54b5e7237556728b8589515d"
 dependencies = [
  "error-chain",
- "libc 0.2.139",
+ "libc",
  "log",
  "time",
 ]
@@ -277,7 +273,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
- "libc 0.2.139",
+ "libc",
  "wasi",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "pam_rssh"
 crate-type = ["cdylib"]
 
 [dependencies]
-pam = { path = "./dep/pam-rs/pam" }
+pam-bindings = "0.1.1"
 ssh-agent = { path = "./dep/ssh-agent.rs" }
 multisock = "^1.0.0"
 byteorder = "1.2.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ fn setup_logger() {
 }
 
 impl PamHooks for PamRssh {
-    fn sm_authenticate(pamh: &PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+    fn sm_authenticate(pamh: &mut PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
         /* if (flags & pam::constants::PAM_SILENT) == 0 */
         {
             setup_logger();
@@ -171,7 +171,7 @@ impl PamHooks for PamRssh {
     }
 
     // Always return PAM_SUCCESS for sm_setcred, just like pam-u2f
-    fn sm_setcred(_pamh: &PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+    fn sm_setcred(_pamh: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
         info!("set-credentials is not implemented");
         PamResultCode::PAM_SUCCESS
     }


### PR DESCRIPTION
The project was updated upsteam.  Switching to it, we can get rid of the `libc = ~0.1.5` dependency that cause trouble on FreeBSD:

```
CARGO_CRATES=libc-0.1.5 may be unstable on FreeBSD 12.0. Consider updating to the latest
version (higher than 0.2.37).

CARGO_CRATES=libc-0.1.5 may be unstable on aarch64 or not build on armv6, armv7, powerpc64.
Consider updating to the latest version (higher than 0.2.49).
```

----


It looks to my that your fork has one commit that was never proposed for integration in the upsteam crate.  There seems to be conflicts with upsteam main branch, but if your change still make sense you should submit it as a PR :wink: 