### PR TITLE
feat: add pam interaction prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ The following arguments are supported:
 - `auth_key_file=<Path to authorized_keys>` Public keys allowed for user authentication. Defaults to `<home>/.ssh/authorized_keys`. `<home>` is read from system configuration, usually it expands to `/home/<username>`.
 - `authorized_keys_command=<Path to command>` A command to generate the authorized_keys. It takes a single argument, the username of the user being authenticated. The standard output of this command will be parsed as authorized_keys. The `auth_key_file` will be ignored if you specify this argument.
 - `authorized_keys_command_user=<Username>` The `authorized_keys_command` will be run as the user specified here. If this argument is omitted, the `authorized_keys_command` will be run as the user being authenticated.
+- `cue` Enable device interaction prompt. When enabled, displays a message reminding the user to touch their device during authentication.
+- `[cue_prompt=<message>]` Set custom prompt message for device interaction. Default: "Please touch the device". Use square brackets to include spaces in the message.
 
 Arguments should be appended to the PAM rule. For example:
 
 ```
-auth sufficient libpam_rssh.so debug authorized_keys_command=/usr/bin/sss_ssh_authorizedkeys authorized_keys_command_user=nobody
+auth sufficient libpam_rssh.so debug authorized_keys_command=/usr/bin/sss_ssh_authorizedkeys authorized_keys_command_user=nobody cue [cue_prompt=long long prompt]
 ```
 
 ## Use Variables in Arguments

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ pub enum RsshErr {
     OptNameErr(String),
     OptValEmptyErr(String),
     OptVarErr(String),
+    SendPromptErr,
 }
 
 impl RsshErr {
@@ -55,6 +56,7 @@ impl Display for RsshErr {
             RsshErr::OptNameErr(name) => format!("Unknown option name `{}`", name),
             RsshErr::OptValEmptyErr(name) => format!("Value of option `{}` is empty", name),
             RsshErr::OptVarErr(name) => format!("Failed to evaluate variables in option `{}`", name),
+            RsshErr::SendPromptErr => S!("Failed to send prompt message"),
         };
         f.write_str(&msg)
     }


### PR DESCRIPTION
Users can enable prompts via` cue` option and customize the message text via `cue_prompt`.