### PR TITLE
Add docker builder script and Dockerfile for cross compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:1.93.0-slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates pkg-config libssl-dev libpam0g-dev openssl \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release
+
+FROM scratch
+COPY --from=builder /app/target/release/libpam_rssh.so /

--- a/README.md
+++ b/README.md
@@ -48,6 +48,32 @@ The `<pam module path>` is specific to certain Linux distributions.
 | Debian       | `/lib/x86_64-linux-gnu/security/`   |
 | openSUSE     | `/lib/security/`                    |
 
+
+## Build using Docker (for cross compilation)
+Clone this repo with **a submodule**.
+
+```
+git clone --recurse-submodule https://github.com/z4yx/pam_rssh.git
+cd pam_rssh
+```
+
+Then build it using Docker. It creates a x86_64 Linux binary (on any platform, tested on Apple Silicon macOS). The resulting library depends on Glibc version 2.34 or newer.
+
+```
+./build.sh
+cp out/libpam_rssh.so <pam module path>
+```
+
+
+The `<pam module path>` is specific to certain Linux distributions.
+
+| OS           | Destination                         |
+| ------------ | ----------------------------------- |
+| Arch Linux   | `/usr/lib/security/`                |
+| Debian       | `/lib/x86_64-linux-gnu/security/`   |
+| openSUSE     | `/lib/security/`                    |
+
+
 ## Config
 
 Add the following line to `/etc/pam.d/sudo` (place it before existing rules):

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --output type=local,dest=./out .


### PR DESCRIPTION
Using build.sh (which uses Docker) it's possible to build the x86_64 Linux library on (at least Apple Silicon Macs) non-Linux platforms. 