### PR TITLE
Send the touch cue at most once per authentication

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,11 +195,15 @@ impl PamHooks for PamRssh {
             }
         };
         
+        // Cue at most once per authentication: the loop below tries every
+        // authorized key, and absent-token keys would each prompt otherwise.
+        let cue_sent = std::cell::Cell::new(false);
         let send_prompt = || -> PamResult<()> {
-            if cue {
+            if cue && !cue_sent.get() {
                 pamh.get_item::<Conv>()?
                     .ok_or(PamResultCode::PAM_BUF_ERR)?
                     .send(PAM_TEXT_INFO, &cue_prompt)?;
+                cue_sent.set(true);
             }
             Ok(())
         };


### PR DESCRIPTION
## Problem

When several authorized keys are configured (for example multiple FIDO/YubiKey
`sk` creds enrolled, with only one token plugged in at a time), the `cue` message
is sent inside the per-key loop. Keys whose hardware token is absent fail their
sign request immediately, but each one still prints "Please touch the device"
first, so the user sees the prompt 2-3 times for a single `sudo`.

Only one key can ever actually sign (the loop returns on the first success), so
every extra prompt is for a key that instantly failed.

## Change

Latch the cue so it is sent at most once per authentication. A `Cell<bool>` keeps
the `send_prompt` closure `Fn`, so the surrounding code is unchanged. The latch is
scoped to the call, so each authentication still gets exactly one prompt.

Single-key setups are unaffected. A custom `cue_prompt` still works; it is shown
once instead of N times.

If you would prefer to keep the current behavior by default and gate this behind
an option, I am happy to adjust.

## Testing

Builds clean against this tree (rust:slim-bookworm with `libpam0g-dev libssl-dev
pkg-config clang`). The cue now fires once per authentication by construction.
