### PR TITLE
Log using libc's syslog(3) rather than the syslog crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,15 +37,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,23 +64,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
-name = "hostname"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-link",
-]
-
-[[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,21 +89,6 @@ name = "multisock"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b00b95a51f8573ee359668dfbfed424212dd0fc74df2333816fddff856f342"
-
-[[package]]
-name = "num-conv"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "openssl"
@@ -183,6 +142,7 @@ version = "1.2.0"
 dependencies = [
  "base64",
  "byteorder",
+ "libc",
  "log",
  "multisock",
  "openssl",
@@ -191,7 +151,6 @@ dependencies = [
  "pwd",
  "ssh-agent",
  "subst",
- "syslog",
 ]
 
 [[package]]
@@ -199,12 +158,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -302,18 +255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syslog"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019f1500a13379b7d051455df397c75770de6311a7a188a699499502704d9f10"
-dependencies = [
- "hostname",
- "libc",
- "log",
- "time",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,39 +275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "libc",
- "num-conv",
- "num_threads",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,9 +291,3 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = "1.5.0"
 base64 = "^0.22.1"
 openssl-sys = "^0.9"
 openssl = "^0.10"
+libc = "^0.2"
 log = { version = "^0.4", features = ["std", "serde"] }
 subst = "^0.3.0"
-syslog = "^7.0"
 pwd = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,13 @@ use pam::items::User;
 use pam::module::{PamHandle, PamHooks, PamResult};
 use ssh_agent::proto::KeyTypeEnum;
 use ssh_agent::proto::public_key::PublicKey;
-use syslog::{BasicLogger, Facility, Formatter3164};
 
 use std::ffi::CStr;
 use std::str::FromStr;
 use pam::conv::Conv;
 use self::error::RsshErr;
 use self::logger::ConsoleLogger;
+use self::logger::SyslogLogger;
 
 type ErrType = Box<dyn std::error::Error>;
 
@@ -77,15 +77,8 @@ fn authenticate_via_agent(
 }
 
 fn setup_logger() {
-    let formatter = Formatter3164 {
-        facility: Facility::LOG_AUTH,
-        hostname: None,
-        process: "pam_rssh".into(),
-        pid: std::process::id() as u32,
-    };
-    syslog::unix(formatter)
+    log::set_boxed_logger(Box::new(SyslogLogger))
         .ok()
-        .and_then(|logger| log::set_boxed_logger(Box::new(BasicLogger::new(logger))).ok())
         .or_else(|| log::set_boxed_logger(Box::new(ConsoleLogger)).ok())
         .map(|()| log::set_max_level(log::LevelFilter::Warn));
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,4 @@
-use log::{Metadata, Record};
+use log::{Level, Metadata, Record};
 
 pub struct ConsoleLogger;
 
@@ -10,6 +10,40 @@ impl log::Log for ConsoleLogger {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             println!("{} - {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+use std::ffi::CStr;
+
+const FMT: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"%s\0") };
+
+pub struct SyslogLogger;
+
+impl log::Log for SyslogLogger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let priority = match record.level() {
+            Level::Error => libc::LOG_ERR,
+            Level::Warn => libc::LOG_WARNING,
+            Level::Info => libc::LOG_INFO,
+            Level::Debug => libc::LOG_DEBUG,
+            Level::Trace => libc::LOG_DEBUG,
+        };
+
+        let msg = std::ffi::CString::new(record.args().to_string()).unwrap();
+
+        unsafe {
+            libc::syslog(priority | libc::LOG_AUTH, FMT.as_ptr(), msg.as_ptr());
         }
     }
 


### PR DESCRIPTION
In order to send messages to syslog, the syslog crate create a message
formatted as defined in RFC 3164 and written to the syslog socket.
Unfortunately, the produced message does not respect the RFC: according
to [RFC3164 Section 4.1.2]:

> The TIMESTAMP field is the local time

But the syslog create use UTC time instead of local time [1] because of
a limitation related to thread safety when getting the local time [2].
pam_rssh is not concerned by the race condition that the rust community
wants to avoid, but nevertheless produce incorrect timestamps in log
messages.  This makes logs less relevant and is likely to cause trouble
when analysing logs.

Remove the syslog crate that cannot be used for serious logging; and
instead use the syslog(3) function from libc that only accept a priority
and a message, and therefore logs the correct time.

This also logs using the calling program name rather that the PAM module
name (which is consistent with other PAM modules).

[RFC3164 Section 4.1.2]: https://www.rfc-editor.org/info/rfc3164/#section-4.1.2
[1]: https://github.com/Geal/rust-syslog/blob/55c578d6cf5e48c5017f3ea9c006cba2a5de0046/src/format.rs#L245
[2]: https://github.com/time-rs/time/issues/380
